### PR TITLE
[1/8] feat: Add nix devshell and direnv support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,4 @@ FodyWeavers.xsd
 
 
 .claude/settings.local.json
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774273680,
+        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "lastModified": 1775034801,
+        "narHash": "sha256-tsecHNsWwr4wSaM2oW9GwafMwE24J+xD8bKDoto3exY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "8d029aa64915e54b7846873d9583af4c9fd21ea4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,13 @@
     {
       devShells = forEachSupportedSystem ({ pkgs }:
         {
-          default = pkgs.mkShell {
+          default =
+            let
+              dotnet = with pkgs.dotnetCorePackages; combinePackages [ sdk_8_0 sdk_10_0 ];
+            in
+            pkgs.mkShell {
             packages = with pkgs; [
-              dotnet-sdk_8
+              dotnet
             ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
               # Native deps for NuGet packages (LibGit2Sharp, SkiaSharp)
               zlib
@@ -31,7 +35,7 @@
               libGL
             ];
             shellHook = ''
-              export DOTNET_ROOT="${pkgs.dotnet-sdk_8}"
+              export DOTNET_ROOT="${dotnet}"
             '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
               export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath (with pkgs; [
                 zlib openssl fontconfig

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
               export DOTNET_ROOT="${dotnet}"
             '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
               export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath (with pkgs; [
-                zlib openssl fontconfig
+                icu zlib openssl fontconfig
                 libx11 libxi libxcursor libxrandr
                 libxext libice libsm libGL
               ])}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+    in
+    {
+      devShells = forEachSupportedSystem ({ pkgs }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              dotnet-sdk_8
+              git
+              gh
+            ] ++ lib.optionals stdenv.isLinux [
+              # Native deps for NuGet packages (LibGit2Sharp, SkiaSharp)
+              zlib
+              openssl
+              fontconfig
+
+              # Avalonia X11 backend
+              libx11
+              libxi
+              libxcursor
+              libxrandr
+              libxext
+              libice
+              libsm
+              libGL
+            ];
+            shellHook = ''
+              export DOTNET_ROOT="${pkgs.dotnet-sdk_8}"
+            '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+              export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath (with pkgs; [
+                zlib openssl fontconfig
+                libx11 libxi libxcursor libxrandr
+                libxext libice libsm libGL
+              ])}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            '';
+          };
+        }
+      );
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,9 +14,7 @@
           default = pkgs.mkShell {
             packages = with pkgs; [
               dotnet-sdk_8
-              git
-              gh
-            ] ++ lib.optionals stdenv.isLinux [
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
               # Native deps for NuGet packages (LibGit2Sharp, SkiaSharp)
               zlib
               openssl

--- a/src/TerminalHost.Avalonia/ViewModels/SparkCanvasViewModel.cs
+++ b/src/TerminalHost.Avalonia/ViewModels/SparkCanvasViewModel.cs
@@ -390,7 +390,7 @@ public partial class SparkCanvasViewModel : BasePanelViewModel, IDisposable
                     {
                         SessionId = session.ClaudeSessionId,
                         DisplayName = session.DisplayName,
-                        ProjectPath = session.WorkingDirectory,
+                        ProjectPath = session.WorkingDirectory ?? "",
                         IsLive = session.IsActive,
                         StartTime = session.StartTime
                     });
@@ -405,12 +405,12 @@ public partial class SparkCanvasViewModel : BasePanelViewModel, IDisposable
                     if (AvailableSessions.Any(s => s.SessionId == state.SessionId))
                         continue;
 
-                    var dirName = state.WorkingDirectory.Split('/', '\\').LastOrDefault(s => s.Length > 0) ?? "Session";
+                    var dirName = state.WorkingDirectory?.Split('/', '\\').LastOrDefault(s => s.Length > 0) ?? "Session";
                     AvailableSessions.Add(new SparkSessionItem
                     {
                         SessionId = state.SessionId,
                         DisplayName = dirName,
-                        ProjectPath = state.WorkingDirectory,
+                        ProjectPath = state.WorkingDirectory ?? "",
                         IsLive = state.Lifecycle == SessionLifecycle.Active,
                         StartTime = state.StartTime
                     });


### PR DESCRIPTION
## Summary

- Add `flake.nix` with .NET 8 + .NET 10 SDKs, Linux native dependencies (X11, OpenGL, SkiaSharp, LibGit2Sharp), and `LD_LIBRARY_PATH` shell hook
- Add `.envrc` for automatic direnv activation
- Include ICU library for .NET globalization support on Linux
- Guard nullable `WorkingDirectory` access in SparkCanvasViewModel

## Details

Provides a reproducible development environment via `nix develop` (or automatic via direnv). The devshell includes:
- .NET SDK 8.0 and 10.0 (combined package)
- Linux-only native library dependencies for Avalonia, SkiaSharp, and LibGit2Sharp
- Proper `LD_LIBRARY_PATH` and `DOTNET_ROOT` configuration

## Test plan

- [ ] Run `nix develop` on a NixOS/nix-enabled Linux system and verify `dotnet build` succeeds
- [ ] Verify direnv auto-activates when entering the project directory
- [ ] Confirm the application runs correctly with the nix-provided dependencies