### PR TITLE
feat: GitHub Releases pipeline (Windows + macOS + Linux artifacts)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - feat
+        - feature
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: CI / Build
+      labels:
+        - ci
+        - build
+        - chore
+    - title: Documentation
+      labels:
+        - docs
+        - documentation
+    - title: Other
+      labels:
+        - '*'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.300
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build Windows artifacts
+    runs-on: windows-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout (full history for MinVer)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Determine version
+        id: version
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF_TYPE -eq 'tag') {
+            $version = $env:GITHUB_REF_NAME -replace '^v', ''
+          } else {
+            dotnet tool install --global minver-cli --version 5.0.0 | Out-Null
+            $version = (minver -t v -p alpha.0).Trim()
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+          Write-Host "Resolved version: $version"
+
+      - name: Publish WPF (TerminalHost) — win-x64
+        shell: pwsh
+        run: |
+          $publishDir = ($env:GITHUB_WORKSPACE -replace '\\', '/') + '/publish/wpf/'
+          dotnet publish src/TerminalHost/TerminalHost -c Release "-p:PublishDir=$publishDir"
+
+      - name: Publish Avalonia — win-x64
+        shell: pwsh
+        run: |
+          $publishDir = ($env:GITHUB_WORKSPACE -replace '\\', '/') + '/publish/avalonia-win/'
+          dotnet publish src/TerminalHost.Avalonia -c Release -r win-x64 "-p:PublishDir=$publishDir"
+
+      - name: Package zips
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          New-Item -ItemType Directory -Force -Path ./artifacts | Out-Null
+          Compress-Archive -Path ./publish/wpf/* `
+            -DestinationPath "./artifacts/host_win-x64_v$version.zip" -Force
+          Compress-Archive -Path ./publish/avalonia-win/* `
+            -DestinationPath "./artifacts/host-avalonia_win-x64_v$version.zip" -Force
+          Get-ChildItem ./artifacts | Format-Table Name, Length
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: terminalhost-windows
+          path: ./artifacts/*.zip
+          retention-days: 7
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build-windows]
+    permissions:
+      contents: write
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: terminalhost-*
+          merge-multiple: true
+          path: ./artifacts
+
+      - name: List downloaded artifacts
+        run: ls -la ./artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./artifacts/*
+          generate_release_notes: true
+          draft: ${{ github.event_name == 'workflow_dispatch' }}
+          prerelease: ${{ github.event_name == 'push' && contains(github.ref_name, '-') }}
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && format('dev-{0}', github.run_number) || github.ref_name }}
+          name: ${{ github.event_name == 'workflow_dispatch' && format('Dev build #{0}', github.run_number) || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,10 +121,62 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+  build-linux:
+    name: Build Linux artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for MinVer)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.300
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            v="${GITHUB_REF_NAME#v}"
+          else
+            dotnet tool install --global minver-cli --version 5.0.0 > /dev/null
+            export PATH="$PATH:$HOME/.dotnet/tools"
+            v=$(minver -t v -p alpha.0)
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $v"
+
+      - name: Publish Avalonia — linux-x64
+        run: |
+          dotnet publish src/TerminalHost.Avalonia -c Release -r linux-x64 \
+            -p:PublishDir=$GITHUB_WORKSPACE/publish/linux/ \
+            -p:InvariantGlobalization=true
+
+      - name: Package tarball
+        run: |
+          VERSION='${{ steps.version.outputs.version }}'
+          DIR="host-avalonia_linux-x64_v$VERSION"
+          mv publish/linux "$DIR"
+          chmod +x "$DIR/host"
+          mkdir -p artifacts
+          tar -czf "artifacts/$DIR.tar.gz" "$DIR"
+          ls -la artifacts/
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: terminalhost-linux
+          path: ./artifacts/*.tar.gz
+          retention-days: 7
+          if-no-files-found: error
+
   release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-windows, build-macos]
+    needs: [build-windows, build-macos, build-linux]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,61 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+  build-macos:
+    name: Build macOS artifacts
+    runs-on: macos-14
+    steps:
+      - name: Checkout (full history for MinVer)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            v="${GITHUB_REF_NAME#v}"
+          else
+            dotnet tool install --global minver-cli --version 5.0.0 > /dev/null
+            export PATH="$PATH:$HOME/.dotnet/tools"
+            v=$(minver -t v -p alpha.0)
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $v"
+
+      - name: Build macOS arm64 DMG
+        run: |
+          chmod +x scripts/build-macos.sh
+          VERSION='${{ steps.version.outputs.version }}' RUNTIME=osx-arm64 ./scripts/build-macos.sh --dmg
+          mkdir -p artifacts
+          mv "publish/host-avalonia_osx-arm64_v${{ steps.version.outputs.version }}.dmg" artifacts/
+
+      - name: Build macOS x64 DMG
+        run: |
+          VERSION='${{ steps.version.outputs.version }}' RUNTIME=osx-x64 ./scripts/build-macos.sh --dmg
+          mv "publish/host-avalonia_osx-x64_v${{ steps.version.outputs.version }}.dmg" artifacts/
+
+      - name: List macOS artifacts
+        run: ls -la ./artifacts
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: terminalhost-macos
+          path: ./artifacts/*.dmg
+          retention-days: 7
+          if-no-files-found: error
+
   release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-windows]
+    needs: [build-windows, build-macos]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout (full history for MinVer)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.300
 
@@ -63,7 +63,7 @@ jobs:
           Get-ChildItem ./artifacts | Format-Table Name, Length
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: terminalhost-windows
           path: ./artifacts/*.zip
@@ -75,12 +75,12 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout (full history for MinVer)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.300
 
@@ -114,7 +114,7 @@ jobs:
         run: ls -la ./artifacts
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: terminalhost-macos
           path: ./artifacts/*.dmg
@@ -126,12 +126,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history for MinVer)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.300
 
@@ -166,7 +166,7 @@ jobs:
           ls -la artifacts/
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: terminalhost-linux
           path: ./artifacts/*.tar.gz
@@ -181,7 +181,7 @@ jobs:
       contents: write
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: terminalhost-*
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,4 +146,4 @@ jobs:
           draft: ${{ github.event_name == 'workflow_dispatch' }}
           prerelease: ${{ github.event_name == 'push' && contains(github.ref_name, '-') }}
           tag_name: ${{ github.event_name == 'workflow_dispatch' && format('dev-{0}', github.run_number) || github.ref_name }}
-          name: ${{ github.event_name == 'workflow_dispatch' && format('Dev build #{0}', github.run_number) || github.ref_name }}
+          name: ${{ github.event_name == 'workflow_dispatch' && format('Dev build {0}', github.run_number) || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.300
 
       - name: Determine version
         id: version
@@ -79,10 +79,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.300
 
       - name: Determine version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           Get-ChildItem ./artifacts | Format-Table Name, Length
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: terminalhost-windows
           path: ./artifacts/*.zip
@@ -114,7 +114,7 @@ jobs:
         run: ls -la ./artifacts
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: terminalhost-macos
           path: ./artifacts/*.dmg
@@ -166,7 +166,7 @@ jobs:
           ls -la artifacts/
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: terminalhost-linux
           path: ./artifacts/*.tar.gz
@@ -181,7 +181,7 @@ jobs:
       contents: write
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: terminalhost-*
           merge-multiple: true
@@ -191,7 +191,7 @@ jobs:
         run: ls -la ./artifacts
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ./artifacts/*
           generate_release_notes: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -604,6 +604,7 @@ All specifications are documented in `docs/specs/`. Status legend:
 | [ContainerizedWorkspaces.md](docs/specs/ContainerizedWorkspaces.md) | Docker-based isolated environments for AI agents with rw/ro volume mounts | **Partial** | Phase 1-3 complete; Phase 4 (advanced) planned |
 | [CollabSync.md](docs/specs/CollabSync.md) | Multi-device collaboration sync bridge (direct/tunnel/relay transports) | **Draft** | Spec complete; not yet implemented |
 | [AgenticMemory.md](docs/specs/AgenticMemory.md) | Agentic long-term memory via Eidet (REST client, Memory Browser, container MCP, settings) | **Completed** | `IEidetService` port with `HttpEidetService` adapter replaces TerminalHost.Memory. Eidet project: [github.com/stevehansen/eidet](https://github.com/stevehansen/eidet) |
+| [GitHubReleases.md](docs/specs/GitHubReleases.md) | GitHub Actions release pipeline producing Windows/macOS/Linux artifacts on tag push; bundles MinVer adoption | **Draft** | Five assets per release; unsigned v1; Updatum-compatible naming |
 
 ## Remaining Work Summary
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -598,13 +598,13 @@ All specifications are documented in `docs/specs/`. Status legend:
 | [Panels.md](docs/specs/Panels.md) | Unified panel system (dock/popup/window states) | **Completed** | Panel transitions, .gitignore support |
 | [CrossPlatform.md](docs/specs/CrossPlatform.md) | Cross-platform support (Windows + macOS) | **Completed** | Core/Windows/macOS/Avalonia projects |
 | [Testing.md](docs/specs/Testing.md) | Unit tests (xUnit) and UI tests (FlaUI) strategy | **Partial** | Infrastructure done; coverage ongoing |
-| [Versioning.md](docs/specs/Versioning.md) | Git tag versioning (MinVer) and auto-updates | **Draft** | Specified but not implemented |
+| [Versioning.md](docs/specs/Versioning.md) | Git tag versioning (MinVer) and auto-updates | **Partial** | MinVer landed via GitHubReleases.md PR; Updatum auto-update consumer not yet implemented |
 | [RestApiAndWebhooks.md](docs/specs/RestApiAndWebhooks.md) | REST API, SSE streaming, webhooks for external integration | **Partial** | Phases 1-3 complete; Phase 4 (Scriban) + Phase 5 (Write/MCP) remaining |
 | [CmdPalExtension.md](docs/specs/CmdPalExtension.md) | PowerToys Command Palette extension (dock band, workspace switcher, git status, tasks) | **Partial** | Phases 1-2 scaffolded; Phase 3-4 planned |
 | [ContainerizedWorkspaces.md](docs/specs/ContainerizedWorkspaces.md) | Docker-based isolated environments for AI agents with rw/ro volume mounts | **Partial** | Phase 1-3 complete; Phase 4 (advanced) planned |
 | [CollabSync.md](docs/specs/CollabSync.md) | Multi-device collaboration sync bridge (direct/tunnel/relay transports) | **Draft** | Spec complete; not yet implemented |
 | [AgenticMemory.md](docs/specs/AgenticMemory.md) | Agentic long-term memory via Eidet (REST client, Memory Browser, container MCP, settings) | **Completed** | `IEidetService` port with `HttpEidetService` adapter replaces TerminalHost.Memory. Eidet project: [github.com/stevehansen/eidet](https://github.com/stevehansen/eidet) |
-| [GitHubReleases.md](docs/specs/GitHubReleases.md) | GitHub Actions release pipeline producing Windows/macOS/Linux artifacts on tag push; bundles MinVer adoption | **Draft** | Five assets per release; unsigned v1; Updatum-compatible naming |
+| [GitHubReleases.md](docs/specs/GitHubReleases.md) | GitHub Actions release pipeline producing Windows/macOS/Linux artifacts on tag push; bundles MinVer adoption | **Completed** | Five assets per release; unsigned v1; Updatum-compatible naming. macOS/Linux smoke-test deferred to first real tag |
 
 ## Remaining Work Summary
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerDefaultPreReleaseIdentifiers>alpha.0</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -10,8 +10,46 @@ It's designed for developers who work with AI coding assistants and need to seam
 |----------|------------|--------------|-------|
 | **Windows** | `host.exe` | WPF (.NET 8) | PowerShell |
 | **macOS** | `host` | Avalonia (.NET 8) | zsh |
+| **Linux** | `host` | Avalonia (.NET 8) | bash / zsh |
 
-Both versions share the same core functionality and configuration format.
+All versions share the same core functionality and configuration format.
+
+## Install
+
+Pre-built binaries are published on the [GitHub Releases page](https://github.com/stevehansen/TerminalHost/releases) for every tagged version. Pick the asset that matches your platform:
+
+| Platform | Asset | Notes |
+|----------|-------|-------|
+| Windows | `host_win-x64_v<version>.zip` | Primary WPF build. Includes Whisper voice support. |
+| Windows | `host-avalonia_win-x64_v<version>.zip` | Alternative Avalonia build (shared codebase with macOS/Linux). |
+| macOS (Apple Silicon) | `host-avalonia_osx-arm64_v<version>.dmg` | |
+| macOS (Intel) | `host-avalonia_osx-x64_v<version>.dmg` | |
+| Linux x64 | `host-avalonia_linux-x64_v<version>.tar.gz` | On minimal distros also install `libice6 libsm6 libfontconfig1`. |
+
+The builds are **unsigned**, so your OS warns you the first time you launch. One-time bypass per platform:
+
+### Windows — SmartScreen warning
+
+1. Extract the zip and double-click `host.exe`.
+2. SmartScreen pops up: _"Windows protected your PC."_
+3. Click **More info**, then **Run anyway**.
+
+### macOS — Gatekeeper "Open Anyway"
+
+On macOS Sequoia (15+) the right-click bypass was removed.
+
+1. Mount the `.dmg` and drag `TerminalHost.app` to `/Applications`.
+2. Try to launch it. macOS will say: _"TerminalHost cannot be opened because Apple cannot check it for malicious software."_
+3. Open **System Settings → Privacy & Security**, scroll to the security message, and click **Open Anyway**.
+4. Confirm with Touch ID or your password.
+
+### Linux
+
+```bash
+tar -xzf host-avalonia_linux-x64_v<version>.tar.gz
+cd host-avalonia_linux-x64_v<version>
+./host
+```
 
 ## Getting Started
 

--- a/docs/specs/GitHubReleases.md
+++ b/docs/specs/GitHubReleases.md
@@ -192,13 +192,13 @@ Add `.github/release.yml` to categorize PRs by label in the auto-generated notes
 ## Phases
 
 **Phase 1 — Versioning groundwork**
-- [ ] Add root `Directory.Build.props` with MinVer.
-- [ ] Replace hardcoded "v1.0" in `HelpView.xaml` with `AssemblyInformationalVersionAttribute` lookup.
-- [ ] Verify `dotnet build` on a clean checkout still succeeds; version shows as `0.0.0-alpha.0.0`.
-- [ ] Tag `v0.1.0-alpha.1` locally, rebuild, verify version string updates.
+- [x] Add root `Directory.Build.props` with MinVer.
+- [x] Replace hardcoded "v1.0" in `HelpView.xaml` with `AssemblyInformationalVersionAttribute` lookup (via `IVersionService` injected into `MainViewModel`, proxied through `HelpViewModel`).
+- [x] Verify `dotnet build` on a clean checkout still succeeds; with no tags MinVer produced `0.0.0-alpha.0.515+<sha>`.
+- [x] Tag `v0.1.0-alpha.1` locally, rebuild, verify version string updates to `0.1.0-alpha.1+<sha>`.
 
 **Phase 2 — Windows release**
-- [ ] Create `.github/workflows/release.yml` with `build-windows` job and a stub `release` job (draft-only).
+- [x] Create `.github/workflows/release.yml` with `build-windows` job and a `release` job (draft on `workflow_dispatch`).
 - [ ] Trigger via `workflow_dispatch`, verify both Windows zips upload to a draft release.
 - [ ] Manually download, extract, and run each on a clean Windows machine (no .NET SDK installed).
 

--- a/docs/specs/GitHubReleases.md
+++ b/docs/specs/GitHubReleases.md
@@ -203,8 +203,8 @@ Add `.github/release.yml` to categorize PRs by label in the auto-generated notes
 - [ ] Manually download, extract, and run each on a clean Windows machine (no .NET SDK installed).
 
 **Phase 3 — macOS release**
-- [ ] Parametrize `scripts/build-macos.sh` to read `$VERSION` and skip codesign when `$SIGNING_IDENTITY` is empty.
-- [ ] Add `build-macos` job invoking the script for both RIDs.
+- [x] Parametrize `scripts/build-macos.sh` to read `$VERSION` and `$RUNTIME`. Codesign was already optional (existing `CODESIGN_IDENTITY` env var with ad-hoc fallback). DMG filename now follows the Updatum convention `host-avalonia_<rid>_v<version>.dmg`. Cleanup narrowed so a second invocation for the other RID does not wipe the first DMG. Plist version sanitized (strips `-prerelease` and `+sha`) to satisfy `CFBundleShortVersionString`.
+- [x] Add `build-macos` job (`macos-14`) invoking the script for both `osx-arm64` and `osx-x64`; cross-publish runs on Apple Silicon.
 - [ ] Verify on a clean Mac: the `.dmg` mounts, the `.app` launches after "Open Anyway".
 
 **Phase 4 — Linux release**

--- a/docs/specs/GitHubReleases.md
+++ b/docs/specs/GitHubReleases.md
@@ -1,0 +1,249 @@
+# GitHub Releases Pipeline
+
+**Status:** Draft
+**Owner:** TBD
+**Related specs:** [Versioning.md](Versioning.md), [CrossPlatform.md](CrossPlatform.md)
+
+## Problem
+
+TerminalHost has no automated release pipeline. The single existing workflow (`.github/workflows/dotnet.yml`) is a `workflow_dispatch` build+test on `windows-latest` with no publish step, and the repository has zero git tags. There is a working local `scripts/build-macos.sh` that produces a `.dmg`, but no Linux equivalent and no CI integration for any platform.
+
+Consequence: users cannot download a runnable build from the GitHub repository homepage. Every install requires checking out the source, installing the .NET 8 SDK, and running `dotnet publish` manually with platform-specific incantations (e.g., the forward-slash `-p:PublishDir` workaround required for Whisper native DLLs).
+
+## Goals
+
+1. Pushing a `v*.*.*` git tag produces a published GitHub Release with downloadable artifacts for Windows, macOS, and Linux.
+2. Artifacts are named per the Updatum convention from [Versioning.md](Versioning.md): `host_<rid>_v<version>.<ext>` (and `host-avalonia_<rid>_v<version>.<ext>` for the Avalonia variant), so the future in-app auto-updater can consume them directly.
+3. Both shippable GUI apps are released side-by-side: the WPF `TerminalHost` (Windows-only, primary product) and the cross-platform `TerminalHost.Avalonia`.
+4. Versioning is derived from git tags via MinVer — no hardcoded version strings.
+5. Manual `workflow_dispatch` runs produce **draft** releases for dry-run testing, never published.
+
+## Non-Goals (v1)
+
+- **Code signing / notarization.** Windows artifacts ship unsigned (SmartScreen warning), macOS `.dmg` ships unsigned (Gatekeeper "Open Anyway"). Document the warnings in README; defer signing infrastructure to a follow-up spec.
+- **Installers.** No MSI/NSIS/Squirrel on Windows, no `.deb`/`.rpm`/AppImage on Linux. Portable zip and `.dmg` only.
+- **ARM Windows / ARM Linux** artifacts. macOS ships both `osx-arm64` and `osx-x64`; everything else is `*-x64` only.
+- **In-app auto-update wiring** (Updatum integration). Asset *naming* must be Updatum-compatible, but consuming the feed is out of scope here — owned by [Versioning.md](Versioning.md).
+- **TerminalHost.CmdPal** (MSIX, ships through Microsoft Store, separate channel).
+- **TerminalHost.Channel** (internal stdio bridge, not user-facing).
+- **Release-please / changelog enforcement.** Use GitHub's built-in `generate_release_notes` from PR titles.
+
+## Solution Overview
+
+A new workflow `.github/workflows/release.yml` triggered by tag push (`v*.*.*`) or manual dispatch. Four jobs run as a fan-out/fan-in:
+
+```
+                   ┌─ build-windows  (windows-latest) ─┐
+   tag push v1.2.3 ┼─ build-macos    (macos-14)       ─┼─→ release (ubuntu-latest)
+                   └─ build-linux    (ubuntu-latest)  ─┘
+```
+
+Build jobs run in parallel, each producing one or more artifacts uploaded via `actions/upload-artifact@v4`. The `release` job depends on all three, downloads everything with `pattern: host*` and `merge-multiple: true`, and creates the GitHub Release via `softprops/action-gh-release@v2` with `generate_release_notes: true`.
+
+MinVer adoption is bundled into this PRD because asset versioning depends on it, and the change is small (one NuGet reference + one property + replacing the hardcoded "v1.0" string in `HelpView.xaml`).
+
+## Detailed Design
+
+### 1. Versioning (MinVer)
+
+Add a repo-root `Directory.Build.props`:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerDefaultPreReleaseIdentifiers>alpha.0</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
+  </ItemGroup>
+</Project>
+```
+
+This applies to every project in the solution including the existing `Directory.Build.props` in `src/TerminalHost.CmdPal/` — that file should be merged or left as-is (CmdPal is out of scope; it can override `<MinVerSkip>true</MinVerSkip>` if MinVer interferes with its MSIX versioning).
+
+Replace the hardcoded version in `src/TerminalHost/TerminalHost/Views/Popups/HelpView.xaml:257` (`"TerminalHost v1.0"`) with a binding to a `VersionString` property on `MainViewModel` (or a small `IVersionService`), reading:
+
+```csharp
+typeof(App).Assembly
+    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+    ?.InformationalVersion ?? "dev";
+```
+
+Tag convention: `v1.2.3`, `v1.2.3-beta.1`. Pre-releases (anything containing `-`) trigger the release workflow but pass `prerelease: true` to `action-gh-release` and are *not* listed as the "latest" release.
+
+### 2. Workflow Triggers
+
+```yaml
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:  # produces a draft release for dry-run testing
+```
+
+The `release` job branches on trigger: tag push → published release; `workflow_dispatch` → draft (`draft: true`).
+
+### 3. Per-Platform Build Steps
+
+All build jobs share these prerequisites:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0   # required for MinVer to see tags
+- uses: actions/setup-dotnet@v4
+  with:
+    dotnet-version: 8.0.x
+```
+
+Version captured into a job env var via `${{ github.ref_name }}` on tag push, or via `dotnet minver` invocation on manual dispatch (so dry runs get a sensible `0.0.0-alpha.0.N` name).
+
+#### 3a. `build-windows` (`windows-latest`)
+
+Builds **both** publishable Windows apps:
+
+**WPF (`TerminalHost`, primary product):**
+```bash
+dotnet publish src/TerminalHost/TerminalHost -c Release \
+  -p:PublishDir=./publish/wpf/
+```
+- The csproj already sets `PublishSingleFile=true`, `SelfContained=true`, `IncludeNativeLibrariesForSelfExtract=true`, `RuntimeIdentifier=win-x64`, plus a custom `CopyWhisperNativeLibs` target that copies four Whisper DLLs and `conpty.dll` next to `host.exe`. **Do not override these on the CLI** — let the csproj drive.
+- Use forward slashes in `PublishDir` per the CLAUDE.md note (Whisper copy target is path-sensitive).
+- Zip the *entire* publish directory (not just `host.exe`) — the loose native DLLs must travel with it.
+
+**Avalonia (`TerminalHost.Avalonia`, secondary):**
+```bash
+dotnet publish src/TerminalHost.Avalonia -c Release -r win-x64 \
+  -p:PublishDir=./publish/avalonia-win/
+```
+
+Artifacts produced:
+- `host_win-x64_v<version>.zip`
+- `host-avalonia_win-x64_v<version>.zip`
+
+#### 3b. `build-macos` (`macos-14`, Apple Silicon)
+
+Adapt `scripts/build-macos.sh` to accept a `$VERSION` env var (currently hardcoded to `1.0.0`) and to skip the codesign block when `$SIGNING_IDENTITY` is empty (unsigned v1).
+
+For each of `osx-arm64` and `osx-x64`:
+1. `dotnet publish src/TerminalHost.Avalonia -c Release -r <rid> -p:PublishDir=...`
+2. Wrap into `.app` bundle (existing script logic): `Contents/MacOS/`, `Contents/Resources/` (including `pty_helper.py`), `Info.plist` with `CFBundleVersion=$VERSION`.
+3. `hdiutil create` into a `.dmg` (script already does this).
+
+Artifacts produced:
+- `host-avalonia_osx-arm64_v<version>.dmg`
+- `host-avalonia_osx-x64_v<version>.dmg`
+
+Universal binary is **not** produced — keep two separate DMGs.
+
+#### 3c. `build-linux` (`ubuntu-latest`)
+
+```bash
+dotnet publish src/TerminalHost.Avalonia -c Release -r linux-x64 \
+  -p:PublishDir=./publish/linux/ \
+  -p:InvariantGlobalization=true
+```
+
+`InvariantGlobalization=true` avoids the libicu runtime dependency on minimal distros (acceptable trade-off for v1 since the UI is English-only; revisit if localization lands).
+
+Generate a `TerminalHost.sh` launcher next to the binary (`cd "$(dirname "$0")" && exec ./TerminalHost.Avalonia "$@"`), `chmod +x` both, then `tar -czf` the publish dir.
+
+Artifacts produced:
+- `host-avalonia_linux-x64_v<version>.tar.gz`
+
+Release notes section to mention `libice6 libsm6 libfontconfig1` as runtime prerequisites on minimal distros.
+
+### 4. Artifact Naming Summary
+
+| RID | Project | Filename |
+|-----|---------|----------|
+| `win-x64` | TerminalHost (WPF) | `host_win-x64_v<version>.zip` |
+| `win-x64` | TerminalHost.Avalonia | `host-avalonia_win-x64_v<version>.zip` |
+| `osx-arm64` | TerminalHost.Avalonia | `host-avalonia_osx-arm64_v<version>.dmg` |
+| `osx-x64` | TerminalHost.Avalonia | `host-avalonia_osx-x64_v<version>.dmg` |
+| `linux-x64` | TerminalHost.Avalonia | `host-avalonia_linux-x64_v<version>.tar.gz` |
+
+Total: **5 assets per release**. The `host_` prefix without a variant suffix is reserved for the WPF primary product (matches Versioning.md verbatim); `host-avalonia_` is the Avalonia variant.
+
+### 5. Release Job
+
+```yaml
+release:
+  runs-on: ubuntu-latest
+  needs: [build-windows, build-macos, build-linux]
+  permissions:
+    contents: write
+  steps:
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: host*
+        merge-multiple: true
+        path: ./artifacts
+    - uses: softprops/action-gh-release@v2
+      with:
+        files: ./artifacts/*
+        generate_release_notes: true
+        draft: ${{ github.event_name == 'workflow_dispatch' }}
+        prerelease: ${{ contains(github.ref_name, '-') }}
+```
+
+Add `.github/release.yml` to categorize PRs by label in the auto-generated notes (Features / Bug Fixes / Other).
+
+## Phases
+
+**Phase 1 — Versioning groundwork**
+- [ ] Add root `Directory.Build.props` with MinVer.
+- [ ] Replace hardcoded "v1.0" in `HelpView.xaml` with `AssemblyInformationalVersionAttribute` lookup.
+- [ ] Verify `dotnet build` on a clean checkout still succeeds; version shows as `0.0.0-alpha.0.0`.
+- [ ] Tag `v0.1.0-alpha.1` locally, rebuild, verify version string updates.
+
+**Phase 2 — Windows release**
+- [ ] Create `.github/workflows/release.yml` with `build-windows` job and a stub `release` job (draft-only).
+- [ ] Trigger via `workflow_dispatch`, verify both Windows zips upload to a draft release.
+- [ ] Manually download, extract, and run each on a clean Windows machine (no .NET SDK installed).
+
+**Phase 3 — macOS release**
+- [ ] Parametrize `scripts/build-macos.sh` to read `$VERSION` and skip codesign when `$SIGNING_IDENTITY` is empty.
+- [ ] Add `build-macos` job invoking the script for both RIDs.
+- [ ] Verify on a clean Mac: the `.dmg` mounts, the `.app` launches after "Open Anyway".
+
+**Phase 4 — Linux release**
+- [ ] Add `build-linux` job.
+- [ ] Verify on Ubuntu 24.04 LTS clean install (with `libice6 libsm6 libfontconfig1` installed): tarball extracts, launcher runs.
+
+**Phase 5 — Production trigger**
+- [ ] Switch trigger to `push: tags: ['v*.*.*']`; remove draft-only restriction for tag pushes.
+- [ ] Add `.github/release.yml` for note categorization.
+- [ ] Cut `v0.1.0` as the first real release.
+- [ ] Update README with download instructions and SmartScreen/Gatekeeper warnings.
+
+## Risks & Open Questions
+
+- **WPF publish flakiness on CI.** The CLAUDE.md note about forward-slash `PublishDir` and the custom `CopyWhisperNativeLibs` target suggests Windows publish is finicky. Mitigation: keep all publish settings in the csproj; never override on the CLI. If the Whisper DLL copy fails on `windows-latest`, fall back to running PowerShell with forward-slash paths explicitly.
+- **macOS runner phase-out.** GitHub is migrating runners; `macos-14` (Apple Silicon) is current. Pin explicitly; don't use `macos-latest` which has shifted meaning before.
+- **`HelpView.xaml` binding context.** It's a popup, not always inside `MainViewModel`'s DataContext chain. May need a small `IVersionService` registered in DI rather than a direct binding. Confirm during Phase 1.
+- **Avalonia version string.** No Help view in the Avalonia project today (per [AvaloniaPortParity.md](AvaloniaPortParity.md)). When that's ported, it needs the same MinVer-fed binding.
+- **First-run experience for unsigned macOS apps.** Sequoia removed the right-click-Open bypass. README must document the Settings → Privacy & Security → "Open Anyway" path explicitly with a screenshot.
+- **Open question: do we want a `latest` redirect?** GitHub provides `releases/latest/download/<asset>` for the most recent non-prerelease. If Updatum uses this in the future, asset naming must be stable across releases (✓ already designed for this).
+
+## Deferred / Out of Scope
+
+| Item | Owner / Trigger |
+|------|-----------------|
+| Windows code signing (EV cert + `signtool`) | Future spec |
+| macOS notarization (Developer ID + `notarytool`) | Future spec |
+| MSI / NSIS / Squirrel Windows installer | Future spec |
+| `.deb` / AppImage / `.rpm` Linux packages | Future spec |
+| ARM64 Windows / ARM64 Linux artifacts | When demand surfaces |
+| In-app auto-update (Updatum consumer) | [Versioning.md](Versioning.md) |
+| Universal macOS binary (`lipo`) | Defer indefinitely; two DMGs are clearer |
+| TerminalHost.CmdPal MSIX release | Microsoft Store, separate channel |
+| TerminalHost.Channel distribution | Internal; bundled with main app if needed |
+
+## Success Criteria
+
+1. `git push origin v0.1.0` produces a GitHub Release at `github.com/<owner>/TerminalHost/releases/tag/v0.1.0` containing all 5 assets.
+2. A user landing on the repository homepage sees the latest release in the right sidebar with downloadable artifacts.
+3. Each downloaded artifact runs on a clean target OS (Windows 11 / macOS 14+ / Ubuntu 24.04) without requiring the .NET SDK.
+4. The Help view's version string matches the released tag exactly.
+5. `workflow_dispatch` runs always produce drafts; tag pushes never produce drafts.

--- a/docs/specs/GitHubReleases.md
+++ b/docs/specs/GitHubReleases.md
@@ -146,7 +146,7 @@ dotnet publish src/TerminalHost.Avalonia -c Release -r linux-x64 \
 
 `InvariantGlobalization=true` avoids the libicu runtime dependency on minimal distros (acceptable trade-off for v1 since the UI is English-only; revisit if localization lands).
 
-Generate a `TerminalHost.sh` launcher next to the binary (`cd "$(dirname "$0")" && exec ./TerminalHost.Avalonia "$@"`), `chmod +x` both, then `tar -czf` the publish dir.
+Avalonia publishes a self-contained single-file `host` binary (per the csproj's `PublishSingleFile` + `IncludeNativeLibrariesForSelfExtract`), so no wrapper launcher is needed. The workflow renames the publish dir to `host-avalonia_linux-x64_v<version>/`, runs `chmod +x host`, and tarballs the dir — extraction produces a folder whose name matches the artifact, and users run `./host` from inside it.
 
 Artifacts produced:
 - `host-avalonia_linux-x64_v<version>.tar.gz`
@@ -208,14 +208,14 @@ Add `.github/release.yml` to categorize PRs by label in the auto-generated notes
 - [ ] Verify on a clean Mac: the `.dmg` mounts, the `.app` launches after "Open Anyway".
 
 **Phase 4 — Linux release**
-- [ ] Add `build-linux` job.
-- [ ] Verify on Ubuntu 24.04 LTS clean install (with `libice6 libsm6 libfontconfig1` installed): tarball extracts, launcher runs.
+- [x] Add `build-linux` job (`ubuntu-latest`) publishing Avalonia for `linux-x64` with `InvariantGlobalization=true`. Tarball contains the renamed publish directory with executable bit set on the `host` binary.
+- [ ] Verify on Ubuntu 24.04 LTS clean install (with `libice6 libsm6 libfontconfig1` installed): tarball extracts, `./host` launches.
 
 **Phase 5 — Production trigger**
-- [ ] Switch trigger to `push: tags: ['v*.*.*']`; remove draft-only restriction for tag pushes.
-- [ ] Add `.github/release.yml` for note categorization.
-- [ ] Cut `v0.1.0` as the first real release.
-- [ ] Update README with download instructions and SmartScreen/Gatekeeper warnings.
+- [x] Trigger already configured in Phase 2: tag push produces a non-draft release; `workflow_dispatch` produces a draft for dry-run testing.
+- [x] Add `.github/release.yml` for note categorization (Features / Bug Fixes / CI Build / Documentation / Other based on PR labels).
+- [ ] Cut `v0.1.0` as the first real release — post-merge user action.
+- [x] Update README with download table, asset naming, and SmartScreen / Gatekeeper "Open Anyway" instructions.
 
 ## Risks & Open Questions
 

--- a/docs/specs/GitHubReleases.md
+++ b/docs/specs/GitHubReleases.md
@@ -1,6 +1,6 @@
 # GitHub Releases Pipeline
 
-**Status:** Draft
+**Status:** Completed
 **Owner:** TBD
 **Related specs:** [Versioning.md](Versioning.md), [CrossPlatform.md](CrossPlatform.md)
 

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -9,9 +9,14 @@ cd "$(dirname "$0")/.."
 # Configuration
 APP_NAME="TerminalHost"
 BUNDLE_ID="com.terminalhost.app"
-VERSION="1.0.0"
+VERSION="${VERSION:-1.0.0}"
 PROJECT_PATH="src/TerminalHost.Avalonia"
 OUTPUT_DIR="publish"
+
+# Plist-safe version: strip prerelease (-alpha.1) and build metadata (+sha)
+# CFBundleShortVersionString requires three integers, so e.g. 1.2.3-beta.1 -> 1.2.3
+PLIST_VERSION="${VERSION%%-*}"
+PLIST_VERSION="${PLIST_VERSION%%+*}"
 
 # Parse arguments
 CREATE_DMG=false
@@ -41,19 +46,29 @@ for arg in "$@"; do
     esac
 done
 
-# Determine architecture
-ARCH=$(uname -m)
-if [ "$ARCH" = "arm64" ]; then
-    RUNTIME="osx-arm64"
+# Determine architecture. Honor RUNTIME env var so CI can build both osx-arm64
+# and osx-x64 from a single Apple-Silicon runner via cross-publish.
+if [ -z "$RUNTIME" ]; then
+    ARCH=$(uname -m)
+    if [ "$ARCH" = "arm64" ]; then
+        RUNTIME="osx-arm64"
+    else
+        RUNTIME="osx-x64"
+    fi
 else
-    RUNTIME="osx-x64"
+    case "$RUNTIME" in
+        osx-arm64) ARCH="arm64" ;;
+        osx-x64)   ARCH="x86_64" ;;
+        *) echo "Unsupported RUNTIME: $RUNTIME (expected osx-arm64 or osx-x64)"; exit 1 ;;
+    esac
 fi
 
 echo "Building TerminalHost for macOS ($ARCH)..."
 
 if [ "$SKIP_BUILD" = false ]; then
-    # Clean previous build
-    rm -rf "$OUTPUT_DIR"
+    # Clean only this run's artifacts so a second invocation for the other
+    # RID does not wipe a DMG already produced.
+    rm -rf "$OUTPUT_DIR/$RUNTIME" "$OUTPUT_DIR/${APP_NAME}.app" "$OUTPUT_DIR/dmg-temp"
 
     # Build the project
     echo "Publishing .NET project..."
@@ -90,9 +105,9 @@ else
     <key>CFBundleIdentifier</key>
     <string>${BUNDLE_ID}</string>
     <key>CFBundleVersion</key>
-    <string>${VERSION}</string>
+    <string>${PLIST_VERSION}</string>
     <key>CFBundleShortVersionString</key>
-    <string>${VERSION}</string>
+    <string>${PLIST_VERSION}</string>
     <key>CFBundleExecutable</key>
     <string>host</string>
     <key>CFBundlePackageType</key>
@@ -154,7 +169,7 @@ if [ "$CREATE_DMG" = true ]; then
     echo ""
     echo "Creating DMG installer..."
 
-    DMG_NAME="${APP_NAME}-${VERSION}-${ARCH}.dmg"
+    DMG_NAME="host-avalonia_${RUNTIME}_v${VERSION}.dmg"
     DMG_PATH="$OUTPUT_DIR/$DMG_NAME"
     DMG_TEMP="$OUTPUT_DIR/dmg-temp"
 

--- a/src/TerminalHost.Core/Interfaces/IVersionService.cs
+++ b/src/TerminalHost.Core/Interfaces/IVersionService.cs
@@ -1,0 +1,8 @@
+namespace TerminalHost.Core.Interfaces;
+
+public interface IVersionService
+{
+    string InformationalVersion { get; }
+
+    string FullInformationalVersion { get; }
+}

--- a/src/TerminalHost.Core/Services/VersionService.cs
+++ b/src/TerminalHost.Core/Services/VersionService.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using TerminalHost.Core.Interfaces;
+
+namespace TerminalHost.Core.Services;
+
+public sealed class VersionService : IVersionService
+{
+    private readonly Assembly _assembly;
+
+    public VersionService()
+        : this(Assembly.GetEntryAssembly() ?? typeof(VersionService).Assembly)
+    {
+    }
+
+    public VersionService(Assembly assembly)
+    {
+        _assembly = assembly;
+    }
+
+    public string FullInformationalVersion =>
+        _assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? "0.0.0";
+
+    public string InformationalVersion
+    {
+        get
+        {
+            var raw = FullInformationalVersion;
+            var plusIndex = raw.IndexOf('+');
+            return plusIndex >= 0 ? raw[..plusIndex] : raw;
+        }
+    }
+}

--- a/src/TerminalHost/TerminalHost/App.xaml.cs
+++ b/src/TerminalHost/TerminalHost/App.xaml.cs
@@ -276,6 +276,7 @@ public partial class App : Application
         services.AddSingleton<IConfigurationService>(sp =>
             new ConfigurationService(sp.GetRequiredService<IFileSystem>(), args.UserDataDir));
         services.AddSingleton<ISystemInfoService, WindowsSystemInfoService>();
+        services.AddSingleton<IVersionService, VersionService>();
         services.AddSingleton<IStatisticsService, StatisticsService>();
         services.AddSingleton<ISystemTrayService, SystemTrayService>();
         services.AddSingleton<IDialogService, DialogService>();

--- a/src/TerminalHost/TerminalHost/ViewModels/HelpViewModel.cs
+++ b/src/TerminalHost/TerminalHost/ViewModels/HelpViewModel.cs
@@ -19,6 +19,8 @@ public partial class HelpViewModel : ObservableObject
         _mainViewModel = mainViewModel;
     }
 
+    public string VersionString => _mainViewModel.VersionString;
+
     #region Keyboard Shortcuts
 
     /// <summary>

--- a/src/TerminalHost/TerminalHost/ViewModels/MainViewModel.cs
+++ b/src/TerminalHost/TerminalHost/ViewModels/MainViewModel.cs
@@ -27,6 +27,9 @@ public partial class MainViewModel : ObservableObject
     private readonly DetectedLinksViewModel _detectedLinksViewModel;
     private readonly IFileSystem _fileSystem;
     private readonly IDialogService _dialogService;
+    private readonly IVersionService _versionService;
+
+    public string VersionString => $"TerminalHost v{_versionService.InformationalVersion}";
 
     private readonly IClaudeCommandService _claudeCommandService;
     private readonly IAiAssistantService _aiAssistantService;
@@ -247,6 +250,7 @@ public partial class MainViewModel : ObservableObject
         DetectedLinksViewModel detectedLinksViewModel,
         IFileSystem fileSystem,
         IDialogService dialogService,
+        IVersionService versionService,
         IClaudeCommandService claudeCommandService,
         IAiAssistantService aiAssistantService,
         IProcessService processService,
@@ -284,6 +288,7 @@ public partial class MainViewModel : ObservableObject
         _detectedLinksViewModel = detectedLinksViewModel;
         _fileSystem = fileSystem;
         _dialogService = dialogService;
+        _versionService = versionService;
         _claudeCommandService = claudeCommandService;
         _aiAssistantService = aiAssistantService;
         _processService = processService;

--- a/src/TerminalHost/TerminalHost/Views/Popups/HelpView.xaml
+++ b/src/TerminalHost/TerminalHost/Views/Popups/HelpView.xaml
@@ -207,7 +207,7 @@
                     <TextBlock Foreground="{StaticResource TextDimmedBrush}"
                            FontSize="{StaticResource FontSizeTiny}"
                            VerticalAlignment="Center"
-                           Text="TerminalHost v1.0"/>
+                           Text="{Binding VersionString}"/>
                 </DockPanel>
             </Border>
         </Grid>

--- a/tests/TerminalHost.Tests/ViewModels/MainViewModelTests.cs
+++ b/tests/TerminalHost.Tests/ViewModels/MainViewModelTests.cs
@@ -26,6 +26,7 @@ public class MainViewModelTests
     private readonly Mock<DetectedLinksViewModel> _mockDetectedLinksViewModel;
     private readonly Mock<IFileSystem> _mockFileSystem;
     private readonly Mock<IDialogService> _mockDialogService;
+    private readonly Mock<IVersionService> _mockVersionService;
     private readonly Mock<IClaudeCommandService> _mockClaudeCommandService;
     private readonly Mock<IAiAssistantService> _mockAiAssistantService;
     private readonly Mock<IGitHubService> _mockGitHubService;
@@ -61,6 +62,9 @@ public class MainViewModelTests
         _mockFileExplorerService = new Mock<IFileExplorerService>();
         _mockFileSystem = new Mock<IFileSystem>();
         _mockDialogService = new Mock<IDialogService>();
+        _mockVersionService = new Mock<IVersionService>();
+        _mockVersionService.SetupGet(v => v.InformationalVersion).Returns("0.0.0-test");
+        _mockVersionService.SetupGet(v => v.FullInformationalVersion).Returns("0.0.0-test+abc");
         _mockClaudeCommandService = new Mock<IClaudeCommandService>();
         _mockAiAssistantService = new Mock<IAiAssistantService>();
         _mockGitHubService = new Mock<IGitHubService>();
@@ -197,6 +201,7 @@ public class MainViewModelTests
             _mockDetectedLinksViewModel.Object,
             _mockFileSystem.Object,
             _mockDialogService.Object,
+            _mockVersionService.Object,
             _mockClaudeCommandService.Object,
             _mockAiAssistantService.Object,
             _mockProcessService.Object,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [x] 📦 Chore (Release)

## Screenshots
<img width="1510" height="877" alt="afbeelding" src="https://github.com/user-attachments/assets/fb240f2d-4dae-49d0-8194-ff30851b3094" />


## Description

Sets up the GitHub Releases pipeline so users can download runnable builds straight from the repository homepage. All five phases of the plan in [`docs/specs/GitHubReleases.md`](docs/specs/GitHubReleases.md) have landed.

**What's in:**

- **Phase 1 — Versioning.** Root `Directory.Build.props` adopts MinVer 5.0.0, so every project (except CmdPal) derives its assembly version from `v*.*.*` git tags. New `IVersionService` (Core) reads `AssemblyInformationalVersion` and strips the `+sha` build metadata for display. Wired through DI → `MainViewModel` → `HelpViewModel`, so the Help popup (F1) renders the live build version in place of the hardcoded `"v1.0"`.

- **Phase 2 — Windows release.** New `.github/workflows/release.yml` with a `build-windows` job (`windows-latest`) that publishes both Windows apps — `TerminalHost` (WPF) and `TerminalHost.Avalonia` for `win-x64` — packaging them as `host_win-x64_v<ver>.zip` and `host-avalonia_win-x64_v<ver>.zip` per the Updatum convention.

- **Phase 3 — macOS release.** Parametrized `scripts/build-macos.sh` to honor `VERSION` and `RUNTIME` env vars (one Apple-Silicon runner cross-publishes both `osx-arm64` and `osx-x64`), narrowed cleanup so consecutive invocations coexist, sanitized `CFBundleShortVersionString`, and renamed the DMG to `host-avalonia_<rid>_v<version>.dmg`. New `build-macos` job (`macos-14`) invokes the script twice and uploads both DMGs.

- **Phase 4 — Linux release.** New `build-linux` job (`ubuntu-latest`) publishes Avalonia for `linux-x64` with `InvariantGlobalization=true` (no libicu dependency). Tarball is `host-avalonia_linux-x64_v<version>.tar.gz` with the `host` binary made executable inside.

- **Phase 5 — Production polish.** Tag-trigger path already wired up in Phase 2 (push → real release, dispatch → draft). Added `.github/release.yml` so auto-generated release notes categorize PRs by label (Features / Bug Fixes / CI Build / Documentation / Other). Added an Install section to `README.md` that links to the Releases page, lists all five artifacts, and documents the SmartScreen + Gatekeeper "Open Anyway" bypass for unsigned builds. Platform Support table gains a Linux row.

- **Misc.** Pinned CI workflows to .NET SDK 10.0.300 to match the local toolchain. Bumped all first-party actions to Node 24-ready versions (`actions/checkout@v6`, `actions/setup-dotnet@v5`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `softprops/action-gh-release@v3`).

## Testing performed (on my fork)

Workflow dispatched twice — both green, both produced draft releases with all 5 expected artifacts:

- [First dispatch (commit `d80ad6f`)](https://github.com/PieterjanDeClippel/TerminalHost/actions/runs/26280892417) — initial run, drove the Node 20 deprecation fix.
- [Second dispatch (commit `a79a802`)](https://github.com/PieterjanDeClippel/TerminalHost/actions/runs/26287795829) — post action-version bump, zero deprecation warnings, all 5 artifacts at version `0.0.0-alpha.0.524`.

**Manually validated on this Windows machine:**

- Downloaded `host_win-x64_v0.0.0-alpha.0.524.zip` from the draft release.
- Extracted and launched `host.exe`. SmartScreen warning appeared and was bypassed via **More info → Run anyway**, exactly as the new README section documents.
- **F1 shows `TerminalHost v0.0.0-alpha.0.524`** — Phase 1 end-to-end proof (MinVer wrote the assembly attribute → `IVersionService` strips `+sha` → `HelpViewModel` proxies → XAML binding).
- `Ctrl+N` opens a project, terminal pair spawns correctly.
- `Ctrl+Shift+P` opens the command palette.
- App closes cleanly via the X button — no entries written to `%APPDATA%\TerminalHost\logs\`.

**Known broken: Avalonia Windows zip.** `host-avalonia_win-x64_*.zip` extracts but the exe doesn't run on Windows. This matches the current state of the Avalonia port (see `AvaloniaPortParity.md`). The artifact stays in the release because it also exercises the cross-publish step used for macOS/Linux. README describes it neutrally as "Alternative Avalonia build" — no claim that it works on Windows.

**Could not test from here (no platform access):** macOS DMGs (arm64 + x64), Linux tarball, and the tag-push path (only meaningful against upstream).

## 👉 What @stevehansen needs to do and test

### Before merging

- [ ] **Review the diff.** Touch points are limited: `release.yml` (new) + `build-macos.sh` (parametrized) + `Directory.Build.props` (MinVer) + `IVersionService` / `VersionService` (new, 8 + 33 lines in Core) + a 3-line passthrough in `HelpViewModel` + a one-line XAML binding change. Everything else is docs (`GitHubReleases.md` PRD + `README.md` install section).
- [ ] **Confirm Actions are enabled on upstream.** Settings → Actions → **Allow all actions and reusable workflows**. Forks have Actions off by default; the upstream may too. If disabled, the workflow won't fire on tag push.
- [ ] _(Optional but recommended)_ **Dry-run on upstream.** After merging to `master`, go to the Actions tab → **Release** workflow → **Run workflow** → leave branch as `master` → **Run workflow**. Wait ~3 minutes. Confirm a draft release titled "Dev build N" is created with 5 assets. Delete the draft after inspecting. This validates upstream's runner environment before you stake a real version tag on it.

### After merging — cut the first real release

- [ ] **Tag and push:**
  ```
  git checkout master && git pull
  git tag v0.1.0
  git push origin v0.1.0
  ```
- [ ] **Watch the workflow run** at https://github.com/stevehansen/TerminalHost/actions — should take ~3 minutes for the three build jobs in parallel, then ~20s for the release job.
- [ ] **Confirm the release page** at `https://github.com/stevehansen/TerminalHost/releases/tag/v0.1.0`:
  - [ ] All 5 assets attached: `host_win-x64_v0.1.0.zip`, `host-avalonia_win-x64_v0.1.0.zip`, `host-avalonia_osx-arm64_v0.1.0.dmg`, `host-avalonia_osx-x64_v0.1.0.dmg`, `host-avalonia_linux-x64_v0.1.0.tar.gz`.
  - [ ] Release is **published** (not draft).
  - [ ] Auto-generated release notes appear and are categorized per `.github/release.yml`.
  - [ ] Release shows up on the repo homepage's right sidebar.

### Test what I couldn't (if you have access)

- [ ] **Windows WPF zip** — I already validated this on my machine, but a fresh re-test on yours never hurts. Extract, run `host.exe`, dismiss SmartScreen, press **F1**, confirm version reads `TerminalHost v0.1.0`.
- [ ] **macOS DMG** (whichever arch matches your Mac): mount → drag `TerminalHost.app` to `/Applications` → first launch hits Gatekeeper → **System Settings → Privacy & Security → Open Anyway** → confirm with Touch ID/password → app launches → F1 shows `TerminalHost v0.1.0`.
- [ ] **Linux x64 tarball** (on Ubuntu / WSL2 / VM): extract with `tar -xzf …`, `cd` into the extracted directory, run `./host`. App launches → F1 shows the version. On minimal Ubuntu also install `libice6 libsm6 libfontconfig1` per the README.

### Explicitly out of scope for v1 (do _not_ block this PR on these)

Windows code signing, macOS notarization, MSI / AppImage / .deb installers, ARM Windows / Linux artifacts, in-app auto-update wiring, CmdPal MSIX, universal macOS binary. Each gets its own follow-up spec when there's user demand.

## Related Tickets & Documents

- Spec: [`docs/specs/GitHubReleases.md`](docs/specs/GitHubReleases.md)
- Touches the long-standing Draft spec at [`docs/specs/Versioning.md`](docs/specs/Versioning.md) by fulfilling its MinVer adoption portion.

## Screenshots/Recordings

_To be added: F1 Help popup showing the live build version string (replaces hardcoded `"TerminalHost v1.0"`)._

## Added to documentation?

- [x] 📜 README.md — new Install section with download links + first-launch bypass instructions
- [ ] 📜 SERVICES.md
- [x] 📜 specific docs/ file — new `docs/specs/GitHubReleases.md` PRD + entry added to the spec index in `CLAUDE.md`
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

See the **What @stevehansen needs to do and test** section above — the post-merge checklist (cut `v0.1.0`, confirm the release page, smoke-test macOS / Linux) is the post-deployment work.
